### PR TITLE
DLWEB-16: bug fixes from checklist

### DIFF
--- a/source/_patterns/00-atoms/iconography/iconography.scss
+++ b/source/_patterns/00-atoms/iconography/iconography.scss
@@ -68,3 +68,9 @@
 .icon-twitter:before {
 	content: "\e902";
 }
+
+.iconography pre {
+	padding: 0 10px;
+	background: transparent;
+	font-size: small;
+}

--- a/source/_patterns/00-atoms/lists/lists.scss
+++ b/source/_patterns/00-atoms/lists/lists.scss
@@ -1,14 +1,16 @@
 ul {
 	list-style: none;
-}
-ul.bulleted {
 	padding-left: 20px;
 }
-ul.bulleted li::before {
+ul li::before {
 	content: "\2022";
 	color: $bullet-green;
 	font-weight: bold;
 	display: inline-block;
 	width: 1em;
 	margin-left: -1em;
+}
+
+.bg-green ul li::before {
+	color: inherit;
 }

--- a/source/_patterns/00-atoms/lists/lists.twig
+++ b/source/_patterns/00-atoms/lists/lists.twig
@@ -1,5 +1,12 @@
 {% if items %}
-	<ul class="bulleted">
+	<div class="bg-green">
+		<ul>
+			{% for item in items %}
+				<li>{{ item }}</li>
+			{% endfor %}
+		</ul>
+	</div>
+	<ul>
 		{% for item in items %}
 			<li>{{ item }}</li>
 		{% endfor %}

--- a/source/_patterns/02-organisms/blog-teaser-cards-list/blog-teaser-cards-list.scss
+++ b/source/_patterns/02-organisms/blog-teaser-cards-list/blog-teaser-cards-list.scss
@@ -1,6 +1,7 @@
 .blog-teaser-cards-list {
 	h2 {
 		color: $heading-white;
+		margin-right: 20px;
 	}
 	.posts-wrapper {
 		padding: 20px;
@@ -75,6 +76,11 @@
 		}
 		a.clickable-content {
 			color: $text-navy;
+		}
+		code,
+		pre {
+			color: white;
+			padding: 0 5px;
 		}
 	}
 }

--- a/source/_patterns/02-organisms/blog-teaser-cards-list/blog-teaser-cards-list.yml
+++ b/source/_patterns/02-organisms/blog-teaser-cards-list/blog-teaser-cards-list.yml
@@ -1,4 +1,4 @@
-heading: Curabitur non nulla sit amet
+heading: Curabitur non nulla sit amet consectetur adipiscing elit
 link_text: Lorem Ipsum
 link_url: '#'
 image_default_src: '/assets/images/examples/post-default.png'
@@ -12,7 +12,7 @@ items:
     image_src: /assets/images/examples/post-1.jpg
     image_alt: ''
   - title: 'Blog Post No Image'
-    content: Lorem ipsum dolor sit amet, consectetur adipiscing elit.  Nunc ut sem vitae risus tristique posuere. Lorem ipsum dolor sit amet, consectetur adipiscing elit.  Nunc ut sem vitae risus tristique posuere.
+    content: Lorem ipsum dolor sit amet, consectetur adipiscing elit.  <code>some code here</code> Nunc ut sem vitae risus tristique posuere. Lorem ipsum dolor sit amet, consectetur adipiscing elit.  Nunc ut sem vitae risus tristique posuere.
     url: '#'
     topic: topic
     topic_url:

--- a/source/_patterns/02-organisms/cta-block-parallax/cta-block-parallax.scss
+++ b/source/_patterns/02-organisms/cta-block-parallax/cta-block-parallax.scss
@@ -13,6 +13,8 @@
 		}
 	}
 	.text-wrapper {
+		padding-top: $spacer*20;
+		padding-bottom: $spacer*20;
 		width: 100%;
 		@include screen-lg() {
 			width: 40%;

--- a/source/_patterns/02-organisms/cta-block-parallax/cta-block-parallax.yml
+++ b/source/_patterns/02-organisms/cta-block-parallax/cta-block-parallax.yml
@@ -3,7 +3,7 @@ heading_level: h1
 subheading: Consectetur
 content: |
   <p>Proin eget tortor risus. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere sit amet ligula.</p>
-link_url: #
+link_url: '#'
 link_text: Lorem Ipsum
 image_src: '/assets/images/art/labby-brain-machine.png'
 image_alt: image alt text

--- a/source/_patterns/02-organisms/header/header.scss
+++ b/source/_patterns/02-organisms/header/header.scss
@@ -5,6 +5,9 @@ header.header {
 	.navbar.navbar-dark {
 		padding-top: 0;
 		.navbar-nav {
+			.nav-item:before {
+				display: none;
+			}
 			.nav-link {
 				color: $white;
 				font-size: 18px;
@@ -56,6 +59,9 @@ header.header {
 		}
 		li {
 			margin-left: 10px;
+			&:before {
+				display: none;
+			}
 			a {
 				color: $icon-grey;
 				&:hover,

--- a/source/_patterns/02-organisms/page-title/page-title.scss
+++ b/source/_patterns/02-organisms/page-title/page-title.scss
@@ -5,6 +5,9 @@
 	overflow: hidden;
 	h1 {
 		margin-bottom: 0;
+		margin-left: auto;
+		margin-right: auto;
+		max-width: 60vw;
 	}
 	.title-content {
 		margin-top: auto;

--- a/source/_patterns/02-organisms/text-cards-list/text-cards-list.scss
+++ b/source/_patterns/02-organisms/text-cards-list/text-cards-list.scss
@@ -2,6 +2,13 @@
 	h2 {
 		font-size: 40px;
 	}
+	.content-intro {
+		margin-top: 10px;
+		a:hover,
+		a:focus {
+			color: darken($link-color, 10%);
+		}
+	}
 	.card-wrapper {
 		margin-top: 40px;
 	}

--- a/source/_patterns/02-organisms/text-cards-list/text-cards-list.twig
+++ b/source/_patterns/02-organisms/text-cards-list/text-cards-list.twig
@@ -4,7 +4,7 @@
 			<div class="col-sm-8">
 				<div class="pre-heading">{{ subheading }}</div>
 				<h2 class="font-weight-bold">{{ heading }}</h2>
-				<div>{{ content }}</div>
+				<div class="content-intro">{{ content }}</div>
 			</div>
 		</div>
 		<div class="row row-eq-height card-wrapper">

--- a/source/_patterns/02-organisms/text-cards-list/text-cards-list.yml
+++ b/source/_patterns/02-organisms/text-cards-list/text-cards-list.yml
@@ -1,6 +1,6 @@
 heading:  Quisque velit nisi quisque velit nisi, pretium ut lacinia in, elementum id enim
 subheading: Subheading
-content: Curabitur aliquet quam id dui posuere blandit. Cras ultricies ligula sed magna dictum porta. Vestibulum ac diam sit amet quam vehicula elementum sed sit amet dui.
+content: Curabitur aliquet quam id dui <a href="#">posuere blandit</a>. Cras ultricies ligula sed magna dictum porta. Vestibulum ac diam sit amet quam vehicula elementum sed sit amet dui.
 items:
   - content: |
       <h3>Card with a Much Longer Title</h3>

--- a/source/_patterns/04-pages/homepage.yml
+++ b/source/_patterns/04-pages/homepage.yml
@@ -14,7 +14,12 @@ cta_block_parallax_2:
   subheading: Consectetur
   content: |
     <p>Proin eget tortor risus. Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.</p>
-  link_url: #
+    <p>Vestibulum ac diam sit amet quam vehicula elementum sed sit amet dui. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Quisque velit nisi, pretium ut lacinia in, elementum id enim.</p>
+    <p>Nulla porttitor accumsan tincidunt. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.</p>
+    <p>Curabitur aliquet quam id dui posuere blandit.</p>
+    <p>Vestibulum ac diam sit amet quam vehicula elementum sed sit amet dui. Vivamus magna justo, lacinia eget consectetur sed, convallis at tellus. Quisque velit nisi, pretium ut lacinia in, elementum id enim.</p>
+    <p>Nulla porttitor accumsan tincidunt. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Donec velit neque, auctor sit amet aliquam vel, ullamcorper sit amet ligula.</p>
+  link_url: '#'
   link_text: Lorem Ipsum
   image_src: '/assets/images/art/labby-at-work.png'
   image_alt: image alt text


### PR DESCRIPTION
- `<code>` in blog excerpts should be visible
- Blog teasers list heading should have a gap between text and button (homepage)
- CTA in pink section on About page should have btn-light class
- Page titles should have max-width so they don't bump against the ray guns (60vw)
- Links in green-bg sections should have a different hover state (currently default is green)
- Add top/bottom padding on the content of parallax sections so they'll still look good if they've got a lot of content (same as row-spacer padding on .text-wrapper)
- add bullets to all lists in content sections
